### PR TITLE
Update Modal example

### DIFF
--- a/examples/accessible-modal/README.md
+++ b/examples/accessible-modal/README.md
@@ -41,7 +41,7 @@ Finally, we need to initialize this component in JavaScript.
 import { Modal } from '@beapi/be-a11y';
 
 Modal.init('.modal', {
-  // Options here
+  closeButtonSelector: '.modal__close'
 });
 ```
 


### PR DESCRIPTION
When using the first example (initialize modal without options), the .modal__close button doesn't close the modal. It's look like we need to specify `closeButtonSelector: '.modal__close'`.