### PR TITLE
Release 2.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,9 +1,7 @@
 name: Tests
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+    branches: [ develop, main ]
 jobs:
   tests_e2e:
     name: Run end-to-end tests
@@ -30,6 +28,8 @@ jobs:
       run: pnpm install --frozen-lockfile
     - name: Install Playwright Chromium
       run: pnpm exec playwright install chromium --with-deps
+    - name: Build demo site for Playwright
+      run: pnpm build:demo
     - name: Run tests
       run: pnpm exec playwright test
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,14 +15,21 @@ jobs:
         version: 10
     - uses: actions/setup-node@v4
       with:
-        node-version: 22
+        node-version-file: package.json
         cache: pnpm
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-playwright-
     - name: Install dependencies
       env:
         PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       run: pnpm install --frozen-lockfile
-    - name: Install Playwright browsers
-      run: pnpm exec playwright install --with-deps
+    - name: Install Playwright Chromium
+      run: pnpm exec playwright install chromium --with-deps
     - name: Run tests
       run: pnpm exec playwright test
       env:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,9 +8,13 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: process.env.CI ? 'npx vite preview --port 5173' : 'npx vite dev',
+    // CI: serve the multi-page demo build (examples/*) from demo-dist — same as `pnpm build:demo` / GitHub Pages.
+    // Local: dev server with root vite config so tests hit /examples/... without a prior build.
+    command: process.env.CI
+      ? 'npx vite preview --config vite.demo.config.mjs --port 5173'
+      : 'npx vite dev --port 5173',
     url: 'http://localhost:5173/',
     reuseExistingServer: !process.env.CI,
-    timeout: 10000,
+    timeout: 30000,
   },
 })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI workflow and Playwright test runner setup, but could cause temporary CI failures if the demo build or Vite preview command differs from test expectations.
> 
> **Overview**
> Playwright E2E CI is updated to run on PRs targeting `develop`/`main`, use Node version from `package.json`, cache Playwright browsers, install only Chromium, and build the demo site (`pnpm build:demo`) before running tests.
> 
> Playwright’s `webServer` command now diverges by environment: **CI** serves the built demo via `vite preview --config vite.demo.config.mjs`, while **local** runs `vite dev` on a fixed port; the server startup timeout is increased to 30s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a1452c21b285aa0a65c623df94769a1784ff51d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->