### PR TITLE
chore: add homepage URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.0",
   "type": "module",
   "description": "Collection of usefull accessible components",
+  "homepage": "https://beapi.github.io/be-a11y/",
   "repository": {
     "type": "git",
     "url": "https://github.com/BeAPI/be-a11y"


### PR DESCRIPTION
Add homepage URL to package.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk metadata-only change; it only affects published package metadata and does not alter runtime code or build behavior.
> 
> **Overview**
> Adds a `homepage` entry to `package.json` (`https://beapi.github.io/be-a11y/`) so the published package metadata links to the project site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 805eaec7311c503f1c8e7dffe3d68c068abc3d3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->