### PR TITLE
docs: remove redundant dates from changelog subheaders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 First stable release of the 2.x line. All changes from `2.0.0-beta.1` through `2.0.0-beta.7` are included; see those sections for detailed component and API notes.
 
-### Changed (2026-04-13)
+### Changed
 
 - CI: Publish to npm from `main` via GitHub Actions using npm Trusted Publishing (OIDC)
 - Pin Node.js to 22.14.0 via Volta (required for npm Trusted Publishing CLI requirements)
 - Playwright: use `defineConfig` in `playwright.config.ts` for current `@playwright/test` exports
 - Align on Vite 7.3.x for library build, dev server, and demo site (single toolchain)
 
-### Fixed (2026-04-13)
+### Fixed
 
 - Tests: resolve duplicate Playwright test title in `Dropdown.test.ts`
 
 ## 2.0.0-beta.7 - 2026-01-08
 
-### Fixed (2026-01-08)
+### Fixed
 
 - Fix `aria-expanded` attribute not updating correctly when closing panels in Accordion component
   - When opening a new panel with `allowMultiple: false`, previously opened panels now correctly have their trigger's `aria-expanded` set to `false`
@@ -30,7 +30,7 @@ First stable release of the 2.x line. All changes from `2.0.0-beta.1` through `2
 
 ## 2.0.0-beta.6 - 2025-12-17
 
-### Fixed (2025-12-17)
+### Fixed
 
 - Fix `closeOnBlur` behavior in Toggle component
   - Toggle no longer closes when focus moves to an element inside the toggled target
@@ -38,7 +38,7 @@ First stable release of the 2.x line. All changes from `2.0.0-beta.1` through `2
 
 ## 2.0.0-beta.5 - 2025-12-15
 
-### Changed (2025-12-15)
+### Changed
 
 - Improve TypeScript build configuration for NPM package compatibility
   - Add `tsconfig.build.json` for generating type declarations (`.d.ts`)
@@ -48,7 +48,7 @@ First stable release of the 2.x line. All changes from `2.0.0-beta.1` through `2
 
 ## 2.0.0-beta.4 - 2025-12-13
 
-### Added (2025-12-13)
+### Added
 
 - Add new Dialog component based on native HTML `<dialog>` element
   - Leverages native browser capabilities (`show()`, `showModal()`, `close()` methods)
@@ -60,7 +60,7 @@ First stable release of the 2.x line. All changes from `2.0.0-beta.1` through `2
 - Add complete Dialog documentation with usage examples
 - Add comparison between Dialog and Modal components in documentation
 
-### Fixed (2025-12-13)
+### Fixed
 
 - Fix TypeScript/ESLint errors in Accordion component
   - Add null safety checks for media query pattern matching


### PR DESCRIPTION
Cleans up the changelog by removing dates from the Added, Changed, and Fixed subheadings, as this information is already provided in the main version headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that only adjusts `CHANGELOG.md` formatting and does not affect runtime behavior.
> 
> **Overview**
> Removes redundant dates from `### Added`/`### Changed`/`### Fixed` subheadings in `CHANGELOG.md`, relying on the version header date instead.
> 
> No release notes content changes beyond these heading formatting tweaks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b0269a4551a01a3cd43f0978f38d886dfb2eb90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->