### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.1 - 2026-07-21
+
+### Added
+
+- Toggle: add `onBlur` and `onEscPressed` callback options
+- Demo site: add GitHub and documentation links on the home page and every example page
+- Demo site: add favicon
+
+### Fixed
+
+- Link: support initializing on the `a[target="_blank"]` element itself (not only descendants), and process every matching link when `hasIcon` is `false` (early `return` stopped after the first link)
+- Toggle: prevent an unintended `onClick` call when closing with Escape
+- Demo site: scope toggle `[aria-hidden="true"]` styles to `#toggle-*` targets so unrelated hidden content is not affected
+
+### Changed
+
+- Move pnpm configuration (`overrides`, `peerDependencyRules`) from `package.json` to `pnpm-workspace.yaml`
+- Add `homepage` field to `package.json` (`https://beapi.github.io/be-a11y/`)
+- Bump development dependencies (`postcss`, Vite, `@babel/core`)
+
 ## 2.0.0 - 2026-04-13
 
 First stable release of the 2.x line. All changes from `2.0.0-beta.1` through `2.0.0-beta.7` are included; see those sections for detailed component and API notes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beapi/be-a11y",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "type": "module",
   "description": "Collection of usefull accessible components",
   "homepage": "https://beapi.github.io/be-a11y/",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release metadata only in the diff (version + changelog); behavioral changes are already in the codebase per the changelog.
> 
> **Overview**
> **Release 2.0.1** — bumps `@beapi/be-a11y` from `2.0.0` to `2.0.1` and documents the patch in `CHANGELOG.md`.
> 
> The changelog entry covers work shipped in this release (not introduced in this diff alone): **Toggle** gains `onBlur` / `onEscPressed` callbacks and no longer fires `onClick` when closing via Escape; **Link** can be initialized on the `a[target="_blank"]` element and processes all matching links when `hasIcon` is false; demo-site links, favicon, and scoped toggle `aria-hidden` CSS; pnpm config moved to `pnpm-workspace.yaml`; `homepage` on `package.json`; dev dependency bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af0278d84f35a87b28d886d3a392e8136c50c6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->